### PR TITLE
Fix Travis, move to ECMAScript BigInts, Update core-lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "core-lib"]
 	path = core-lib
 	url = https://github.com/SOM-st/SOM.git
-[submodule "libs/big-integer"]
-	path = libs/big-integer
-	url = https://github.com/smarr/BigInteger.js.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 7
   - 11
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "7"
+  - 7
+  - 11
 
 before_install:
   - pip install pyyaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "7"
 
 before_install:
+  - pip install pyyaml
   - make travis_deps
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,6 @@ core-lib/Smalltalk:
 	git submodules init
 	git submodules update
 
-libs/big-integer/BigInteger.js:
-	git submodules init
-	git submodules update
-
 clean:
 	@rm -Rf build
 	@rm -Rf src_gen

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 JS_SRC=$(shell libs/deps.py)
 CLOJURE_JAR=build/closure-compiler/compiler.jar
 
+SOM_SRC=$(wildcard core-lib/**/*.som)
+
 all: build/som.min.js build/node.min.js build/som.full.js build/som-repl.min.js build/som-repl.full.js
 
 src_gen:
@@ -35,7 +37,7 @@ build/som-repl.full.js: $(JS_SRC) src/web-repl.js
 build/som-repl.min.js: $(JS_SRC) src/web-repl.js $(CLOJURE_JAR)
 	java -jar $(CLOJURE_JAR) --language_in=ECMASCRIPT6_STRICT --js_output_file=$@ $(JS_SRC) src/web-repl.js
 
-src_gen/core_lib.js: core-lib src_gen
+src_gen/core_lib.js: core-lib src_gen $(SOM_SRC)
 	libs/jsify-core-lib.py > $@
 
 core-lib: core-lib/Smalltalk
@@ -45,5 +47,9 @@ core-lib/Smalltalk:
 	git submodules update
 
 clean:
+	@rm -Rf build/*.js
+	@rm -Rf src_gen/*.js
+
+clobber:
 	@rm -Rf build
 	@rm -Rf src_gen

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ syntax tree interpreter. It isn't optimized or tuned for performance. However,
 some aspects were easier to implement by doing node-replacement in a
 self-optimizing interpreter style.
 
-To clone the repository, please use the `--recursive` option to load all 
+To clone the repository, please use the `--recursive` option to load all
 submodules:
 
     $ git clone --recursive https://github.com/SOM-st/JsSOM.git
@@ -38,14 +38,13 @@ JsSOM's tests can be executed with:
 
     $ make  # note, it will download the Google Closure compiler
     $ ./som.sh -cp Smalltalk TestSuite/TestHarness.som
-   
+
 A simple Hello World program is executed with:
 
     $ ./som.sh -cp Smalltalk Examples/Hello.som
 
 This code is distributed under the MIT License. Please see the LICENSE file for
-details. JsSOM uses [BigInteger.js][big-int] to support arbitrary-length
-integer operations. To build JsSOM, you'll further need PyYAML.
+details. To build JsSOM, you'll further need PyYAML.
 
 Build Status
 ------------

--- a/jsTestDriver.conf
+++ b/jsTestDriver.conf
@@ -1,5 +1,4 @@
 load:
-  - libs/big-integer/BigInteger.js
   - src_gen/core_lib.js
   - src/lib/platform.js
   - src/lib/assert.js

--- a/jsTestDriver.conf
+++ b/jsTestDriver.conf
@@ -18,7 +18,7 @@ load:
   - src/som/interpreter/Node.js
   - src/som/interpreter/BlockNode.js
   - src/som/interpreter/ContextualNode.js
-  - src/som/interpreter/ArgumentReadNode.js
+  - src/som/interpreter/ArgumentNode.js
   - src/som/interpreter/DispatchNode.js
   - src/som/interpreter/FieldNode.js
   - src/som/interpreter/Frame.js

--- a/src/som/compiler/Lexer.js
+++ b/src/som/compiler/Lexer.js
@@ -181,15 +181,43 @@ function Lexer(fileContent) {
         } while (/\d/.test(currentChar()));
     }
 
+    function lexEscapeChar() {
+        const current = currentChar();
+
+        switch (current) {
+            case 't':  state.text += "\t"; break;
+            case 'b':  state.text += "\b"; break;
+            case 'n':  state.text += "\n"; break;
+            case 'r':  state.text += "\r"; break;
+            case 'f':  state.text += "\f"; break;
+            case '\'': state.text += "'"; break;
+            case '\\': state.text += "\\"; break;
+        }
+        state.linePos++;
+    }
+
+    function lexStringChar() {
+        if (currentChar() === '\\') {
+            state.linePos++;
+            lexEscapeChar();
+        } else {
+            state.text += currentChar();
+            state.linePos++;
+        }
+    }
+
     function lexString() {
         state.set(Sym.STString, "");
+        state.linePos++
 
-        do {
-            state.text += bufchar(++state.linePos);
+        while (currentChar() != '\'') {
+            lexStringChar();
+            while (endOfLine()) {
+                if (!readNextLine()) { return; }
+                state.text += "\n";
+            }
         }
-        while (currentChar() != '\'');
 
-        state.text = state.text.slice(0, -1);
         state.linePos++;
     }
 

--- a/src/som/compiler/Lexer.js
+++ b/src/som/compiler/Lexer.js
@@ -79,6 +79,10 @@ function Lexer(fileContent) {
         return state.startCoord;
     };
 
+    this.getPeekDone = function () {
+        return peekDone;
+    }
+
     this.getSym = function () {
         if (peekDone) {
             peekDone = false;

--- a/src/som/compiler/Lexer.js
+++ b/src/som/compiler/Lexer.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -132,8 +132,7 @@ function Lexer(fileContent) {
                 }
                 state.sym = Sym.Separator;
             } else {
-                state.linePos++;
-                state.set(Sym.Minus, "-");
+                lexOperator();
             }
         } else if (isOperator(currentChar())) {
             lexOperator();
@@ -226,6 +225,8 @@ function Lexer(fileContent) {
             match(Sym.At);
         } else if (currentChar() == '%') {
             match(Sym.Per);
+        } else if (currentChar() == '-') {
+            match(Sym.Minus);
         }
     }
 
@@ -323,7 +324,7 @@ function Lexer(fileContent) {
     function isOperator(c) {
         return c == '~'  || c == '&' || c == '|' || c == '*' || c == '/'
             || c == '\\' || c == '+' || c == '=' || c == '>' || c == '<'
-            || c == ','  || c == '@' || c == '%';
+            || c == ','  || c == '@' || c == '%' || c == '-';
     }
 
     function match(s) {

--- a/src/som/compiler/MethodGenerationContext.js
+++ b/src/som/compiler/MethodGenerationContext.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -170,21 +170,9 @@ function MethodGenerationContext(holderGenc, outerGenc, blockMethod) {
     };
 
     this.getLocalWriteNode = function (variableName, valExpr, source) {
-        var variable = _this.getLocal(variableName);
+        var variable = _this.getVariable(variableName);
         return variable.getWriteNode(_this.getContextLevel(variableName),
             valExpr, source);
-    };
-
-    this.getLocal = function (varName) {
-        var i = localNames.indexOf(varName);
-        if (i != -1) {
-            return locals[i];
-        }
-
-        if (outerGenc != null) {
-            return outerGenc.getLocal(varName);
-        }
-        return null;
     };
 
     this.getNonLocalReturn = function (expr, source) {

--- a/src/som/compiler/Parser.js
+++ b/src/som/compiler/Parser.js
@@ -43,16 +43,16 @@ function ParseError(message, expected, parser) {
         _this            = this;
 
     this.expectedSymbolAsString = function () {
-        return expected.toString();
+        return Sym.toString(expected);
     };
 
     this.toString = function () {
         var msg = "%(file)s:%(line)d:%(column)d: error: " + message;
         var foundStr;
         if (printableSymbol(found)) {
-            foundStr = found + " (" + text + ")";
+            foundStr = Sym.toString(found) + " (" + text + ")";
         } else {
-            foundStr = found.toString();
+            foundStr = Sym.toString(found);
         }
         msg += ": " + currentLine;
         var expectedStr = _this.expectedSymbolAsString();

--- a/src/som/compiler/Parser.js
+++ b/src/som/compiler/Parser.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -618,7 +618,7 @@ function Parser(fileContent, fileName) {
         if (isInIntRange(i)) {
             return createLiteralNode(universe.newInteger(i), source);
         } else {
-            return createLiteralNode(universe.newBiginteger(bigInt(i)), source);
+            return createLiteralNode(universe.newBigInteger(BigInt(i)), source);
         }
     }
 

--- a/src/som/compiler/Parser.js
+++ b/src/som/compiler/Parser.js
@@ -572,37 +572,63 @@ function Parser(fileContent, fileName) {
     }
 
     function literal() {
+        var coord = _this.getCoordinate();
+        var value;
         switch (sym) {
-            case Sym.Pound:     return literalSymbol();
-            case Sym.STString:  return literalString();
-            default:            return literalNumber();
+            case Sym.Pound: {
+                peekForNextSymbolFromLexerIfNecessary();
+
+                if (nextSym == Sym.NewTerm) {
+                    value = literalArray();
+                } else {
+                    value = literalSymbol();
+                }
+                break;
+            }
+            case Sym.STString: {
+                value = literalString();
+                break;
+            }
+            default: {
+                value = literalNumber();
+                break;
+            }
         }
+        var source = getSource(coord);
+        return createLiteralNode(value, source);
     }
 
     function literalNumber() {
-        var coord = _this.getCoordinate();
-
         if (sym == Sym.Minus) {
-            return negativeDecimal(coord);
+            return negativeDecimal();
         } else {
-            return literalDecimal(false, coord);
+            return literalDecimal(false);
         }
     }
 
-    function literalDecimal(isNegative, coord) {
+    function literalDecimal(isNegative) {
         if (sym == Sym.Integer) {
-            return literalInteger(isNegative, coord);
+            return literalInteger(isNegative);
         } else {
-            return literalDouble(isNegative, coord);
+            return literalDouble(isNegative);
         }
     }
 
-    function negativeDecimal(coord) {
+    function negativeDecimal() {
         expect(Sym.Minus);
-        return literalDecimal(true, coord);
+        return literalDecimal(true);
     }
 
-    function literalInteger(isNegative, coord) {
+    function isNegativeNumber() {
+        var isNegative  = false;
+        if (sym === Sym.Minus) {
+            expect(Sym.Minus);
+            _this.isNegative = true;
+        }
+        return isNegative;
+    }
+
+    function literalInteger(isNegative) {
         var i = parseInt(text, 10);
         if (isNaN(i)) {
             throw new ParseError("Could not parse integer. Expected a number " +
@@ -614,15 +640,14 @@ function Parser(fileContent, fileName) {
         }
         expect(Sym.Integer);
 
-        var source = getSource(coord);
         if (isInIntRange(i)) {
-            return createLiteralNode(universe.newInteger(i), source);
+            return universe.newInteger(i);
         } else {
-            return createLiteralNode(universe.newBigInteger(BigInt(i)), source);
+            return universe.newBigInteger(BigInt(i));
         }
     }
 
-    function literalDouble(isNegative, coord) {
+    function literalDouble(isNegative) {
         var d = parseFloat(text);
         if (isNaN(d)) {
             throw new ParseError("Could not parse double. Expected a number " +
@@ -633,29 +658,62 @@ function Parser(fileContent, fileName) {
             d = 0.0 - d;
         }
         expect(Sym.Double);
-        var source = getSource(coord);
-        return createLiteralNode(universe.newDouble(d), source);
+        return universe.newDouble(d);
     }
 
     function literalSymbol() {
-        var coord = _this.getCoordinate();
-
-        var symb;
         expect(Sym.Pound);
         if (sym == Sym.STString) {
             var s = string();
-            symb = universe.symbolFor(s);
+            return universe.symbolFor(s);
         } else {
-            symb = selector();
+            return selector();
         }
-
-        return createLiteralNode(symb, getSource(coord));
     }
 
     function literalString() {
-        var coord = _this.getCoordinate();
         var s = string();
-        return createLiteralNode(universe.newString(s), getSource(coord));
+        return universe.newString(s);
+    }
+
+    function literalArray() {
+        const literals = [];
+        expect(Sym.Pound);
+        expect(Sym.NewTerm);
+
+        while (sym != Sym.EndTerm) {
+            literals.push(getObjectForCurrentLiteral());
+        }
+
+        expect(Sym.EndTerm);
+        return universe.newArrayFrom(literals);
+    }
+
+    function getObjectForCurrentLiteral() {
+        var coord = _this.getCoordinate();
+
+        switch (sym) {
+            case Sym.Pound: {
+                peekForNextSymbolFromLexerIfNecessary();
+
+                if (nextSym == Sym.NewTerm) {
+                    return literalArray();
+                } else {
+                    return literalSymbol();
+                }
+            }
+            case Sym.STString:
+                return literalString();
+            case Sym.Integer:
+                return literalInteger(isNegativeNumber(), coord);
+            case Sym.Double:
+                return literalDouble(isNegativeNumber(), coord);
+            case Sym.Identifier:
+                expect(Sym.Identifier);
+                return universe.getGlobal(universe.symbolFor(new String(text)));
+            default:
+                throw new ParseError("Could not parse literal array value", Sym.NONE, this);
+        }
     }
 
     function selector() {
@@ -770,6 +828,12 @@ function Parser(fileContent, fileName) {
 
     function peekForNextSymbolFromLexer() {
         nextSym = lexer.peek();
+    }
+
+    function peekForNextSymbolFromLexerIfNecessary() {
+        if (!lexer.getPeekDone()) {
+            peekForNextSymbolFromLexer();
+        }
     }
 
     // init...

--- a/src/som/compiler/Parser.js
+++ b/src/som/compiler/Parser.js
@@ -746,7 +746,7 @@ function Parser(fileContent, fileName) {
     }
 
     function variableWrite(mgenc, variableName, exp, source) {
-        var variable = mgenc.getLocal(variableName);
+        var variable = mgenc.getVariable(variableName);
         if (variable != null) {
             return mgenc.getLocalWriteNode(variableName, exp, source);
         }

--- a/src/som/compiler/Symbol.js
+++ b/src/som/compiler/Symbol.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,3 +54,41 @@ var Sym = {
     KeywordSequence  : 31,
     OperatorSequence : 32
 };
+
+Sym.toString = function(sym) {
+  var arr = [
+    "NONE",
+    "Integer",
+    "Double",
+    "Not",
+    "And",
+    "Or",
+    "Star",
+    "Div",
+    "Mod",
+    "Plus",
+    "Minus",
+    "Equal",
+    "More",
+    "Less",
+    "Comma",
+    "At",
+    "Per",
+    "NewBlock",
+    "EndBlock",
+    "Colon",
+    "Period",
+    "Exit",
+    "Assign",
+    "NewTerm",
+    "EndTerm",
+    "Pound",
+    "Primitive",
+    "Separator",
+    "STString",
+    "Identifier",
+    "Keyword",
+    "KeywordSequence",
+    "OperatorSequence"];
+  return arr[sym];
+}

--- a/src/som/compiler/Variable.js
+++ b/src/som/compiler/Variable.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,6 +33,10 @@ function Argument(name, index) {
     this.getReadNode = function (contextLevel, source) {
         return createArgumentRead(_this, contextLevel, source);
     };
+
+    this.getWriteNode = function (contextLevel, valueExpr, source) {
+        return createArgumentWrite(this, contextLevel, valueExpr, source);
+    }
 
     this.getSuperReadNode = function (contextLevel, holderClass, classSide, source) {
         return createSuperRead(

--- a/src/som/interpreter/ArgumentNode.js
+++ b/src/som/interpreter/ArgumentNode.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,6 +31,23 @@ function ArgumentReadNode(contextLevel, arg, source) {
     };
 }
 ArgumentReadNode.prototype = Object.create(ContextualNode.prototype);
+
+function ArgumentWriteNode(contextLevel, arg, _valueExpr, source) {
+    ContextualNode.call(this, contextLevel, source);
+    var _this = this;
+    _this._child_value = _this.adopt(_valueExpr);
+
+    assert(arg.getIndex() >= 0);
+
+    this.execute = function (frame) {
+        var val = _this._child_value.execute(frame);
+
+        var ctx = _this.determineContext(frame);
+        ctx.setArgument(arg.getIndex(), val);
+        return val;
+    };
+}
+ArgumentWriteNode.prototype = Object.create(ContextualNode.prototype);
 
 function SuperReadNode(holderClass, classSide, contextLevel, arg, source) {
     ArgumentReadNode.call(this, contextLevel, arg, source);

--- a/src/som/interpreter/Frame.js
+++ b/src/som/interpreter/Frame.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,6 +33,10 @@ function Frame(callerFrame, args, numTemps) {
 
     this.getArgument = function (idx) {
         return args[idx];
+    };
+
+    this.setArgument = function (idx, val) {
+        args[idx] = val;
     };
 
     this.getTemp = function (idx) {

--- a/src/som/interpreter/NodeFactory.js
+++ b/src/som/interpreter/NodeFactory.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,6 +38,10 @@ function createFieldWrite(self, exp, fieldIndex, source) {
 
 function createArgumentRead(arg, contextLevel, source) {
     return new ArgumentReadNode(contextLevel, arg, source);
+}
+
+function createArgumentWrite(arg, contextLevel, exp, source) {
+    return new ArgumentWriteNode(contextLevel, arg, exp, source);
 }
 
 function createVariableRead(local, contextLevel, source) {

--- a/src/som/primitives/DoublePrimitives.js
+++ b/src/som/primitives/DoublePrimitives.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,8 +30,12 @@ function DoublePrimitives() {
         if (obj instanceof SInteger) {
             return universe.newDouble(obj.getEmbeddedInteger());
         }
-        throw IllegalStateException("Cannot coerce " + obj.toSource()
+        throw new IllegalStateException("Cannot coerce " + obj.toSource()
             + " to Double!");
+    }
+
+    function _asInteger(frame, args) {
+        return args[0].primAsInteger();
     }
 
     function _asString(frame, args) {
@@ -76,7 +80,22 @@ function DoublePrimitives() {
         return universe.newInteger(intVal);
     }
 
+    function _sin(frame, args) {
+        var val = Math.sin(args[0].getEmbeddedDouble());
+        return universe.newDouble(val);
+    }
+
+    function _cos(frame, args) {
+        var val = Math.cos(args[0].getEmbeddedDouble());
+        return universe.newDouble(val);
+    }
+
+    function _positiveInfinity(frame, args) {
+        return universe.newDouble(Number.POSITIVE_INFINITY);
+    }
+
     this.installPrimitives = function () {
+        _this.installInstancePrimitive("asInteger", _asInteger);
         _this.installInstancePrimitive("asString",  _asString);
         _this.installInstancePrimitive("round",     _round);
         _this.installInstancePrimitive("sqrt",      _sqrt);
@@ -87,6 +106,10 @@ function DoublePrimitives() {
         _this.installInstancePrimitive("%",         _mod);
         _this.installInstancePrimitive("=",         _equals);
         _this.installInstancePrimitive("<",         _lessThan);
+        _this.installInstancePrimitive("sin",       _sin);
+        _this.installInstancePrimitive("cos",       _cos);
+
+        _this.installClassPrimitive("PositiveInfinity", _positiveInfinity);
     }
 }
 DoublePrimitives.prototype = Object.create(Primitives.prototype);

--- a/src/som/primitives/IntegerPrimitives.js
+++ b/src/som/primitives/IntegerPrimitives.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -96,9 +96,9 @@ function IntegerPrimitives() {
 
         var result = l << r;
         if (Math.floor(l) != l || !isInIntRange(result) || !isInIntRange(l * Math.pow(2, r))) {
-            var big = bigInt(l);
-            big = big.multiply(Math.pow(2, r));
-            return universe.newBiginteger(big);
+            var big = BigInt(l);
+            big = big * BigInt(Math.pow(2, r));
+            return universe.newBigInteger(big);
         }
         return universe.newInteger(result);
     }

--- a/src/som/primitives/IntegerPrimitives.js
+++ b/src/som/primitives/IntegerPrimitives.js
@@ -110,6 +110,28 @@ function IntegerPrimitives() {
             ^ right.getEmbeddedInteger())
     }
 
+    function _rem(frame, args) {
+        var right = args[1];
+        var left  = args[0];
+        return universe.newInteger(left.getEmbeddedInteger()
+            % right.getEmbeddedInteger())
+    }
+
+    function _as32BitUnsignedValue(frame, args) {
+        return args[0].prim32BitUnsignedValue();
+    }
+
+    function _as32BitSignedValue(frame, args) {
+        return args[0].prim32BitSignedValue();
+    }
+
+    function _unsignedRightShift(frame, args) {
+        var right = args[1];
+        var left  = args[0];
+        return universe.newInteger(
+            left.getEmbeddedInteger() >>> right.getEmbeddedInteger());
+    }
+
     this.installPrimitives = function () {
         _this.installInstancePrimitive("asString", _asString);
         _this.installInstancePrimitive("sqrt",     _sqrt);
@@ -125,6 +147,11 @@ function IntegerPrimitives() {
         _this.installInstancePrimitive("<",        _lessThan);
         _this.installInstancePrimitive("<<",       _leftShift);
         _this.installInstancePrimitive("bitXor:",  _bitXor);
+        _this.installInstancePrimitive("rem:",     _rem);
+        _this.installInstancePrimitive(">>>",      _unsignedRightShift);
+
+        _this.installInstancePrimitive("as32BitUnsignedValue", _as32BitUnsignedValue);
+        _this.installInstancePrimitive("as32BitSignedValue",   _as32BitSignedValue);
 
         _this.installClassPrimitive("fromString:", _fromString);
     }

--- a/src/som/primitives/IntegerPrimitives.js
+++ b/src/som/primitives/IntegerPrimitives.js
@@ -74,6 +74,10 @@ function IntegerPrimitives() {
         return args[0].primEquals(args[1]);
     }
 
+    function _equalsEquals(frame, args) {
+        return args[0].primEquals(args[1]);
+    }
+
     function _lessThan(frame, args) {
         return args[0].primLessThan(args[1]);
     }
@@ -144,6 +148,7 @@ function IntegerPrimitives() {
         _this.installInstancePrimitive("%",        _mod);
         _this.installInstancePrimitive("&",        _and);
         _this.installInstancePrimitive("=",        _equals);
+        _this.installInstancePrimitive("==",       _equalsEquals, true);
         _this.installInstancePrimitive("<",        _lessThan);
         _this.installInstancePrimitive("<<",       _leftShift);
         _this.installInstancePrimitive("bitXor:",  _bitXor);

--- a/src/som/primitives/Primitives.js
+++ b/src/som/primitives/Primitives.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,12 +38,12 @@ function Primitives () {
         _this.installPrimitives();
     };
 
-    this.installInstancePrimitive = function (selector, primFun) {
+    this.installInstancePrimitive = function (selector, primFun, suppressWarning) {
         var signature = universe.symbolFor(selector);
 
         // Install the given primitive as an instance primitive in the holder class
         holder.addInstancePrimitive(universe.newPrimitive(
-            signature, primFun, holder));
+            signature, primFun, holder), suppressWarning);
     };
 
     this.installClassPrimitive = function (selector, primFun) {

--- a/src/som/vm/Universe.js
+++ b/src/som/vm/Universe.js
@@ -288,10 +288,10 @@ function Universe() {
         initializeSystemClass(som.nilClass,       som.objectClass,  "Nil");
         initializeSystemClass(som.arrayClass,     som.objectClass,  "Array");
         initializeSystemClass(som.methodClass,    som.objectClass,  "Method");
-        initializeSystemClass(som.symbolClass,    som.objectClass,  "Symbol");
         initializeSystemClass(som.integerClass,   som.objectClass,  "Integer");
         initializeSystemClass(som.primitiveClass, som.objectClass,  "Primitive");
         initializeSystemClass(som.stringClass,    som.objectClass,  "String");
+        initializeSystemClass(som.symbolClass,    som.stringClass,  "Symbol");
         initializeSystemClass(som.doubleClass,    som.objectClass,  "Double");
         initializeSystemClass(som.booleanClass,   som.objectClass,  "Boolean");
         initializeSystemClass(som.trueClass,      som.booleanClass, "True");

--- a/src/som/vm/Universe.js
+++ b/src/som/vm/Universe.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -455,8 +455,8 @@ function Universe() {
         return new SInteger(intVal);
     };
 
-    this.newBiginteger = function (bigIntVal) {
-        return new SBigInteger(bigIntVal);
+    this.newBigInteger = function (BigIntVal) {
+        return new SBigInteger(BigIntVal);
     };
 
     this.newBlock = function (blockMethod, contextFrame) {

--- a/src/som/vmobjects/SBigInteger.js
+++ b/src/som/vmobjects/SBigInteger.js
@@ -133,5 +133,15 @@ function SBigInteger(bigintVal) {
         }
         return (result) ? som.trueObject : som.falseObject;
     };
+
+    this.prim32BitUnsignedValue = function () {
+        var val = Number(bigintVal) >>> 0;
+        return intOrBigInt(val);
+    }
+
+    this.prim32BitSignedValue = function () {
+        var val = Number(bigintVal) >> 0;
+        return intOrBigInt(val);
+    }
 }
 SBigInteger.prototype = Object.create(SAbstractObject.prototype);

--- a/src/som/vmobjects/SBigInteger.js
+++ b/src/som/vmobjects/SBigInteger.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,9 +35,9 @@ function SBigInteger(bigintVal) {
         if (right instanceof SDouble) {
             result = bigintVal.toJSNumber() < right;
         } else if (right instanceof SInteger) {
-            result = bigintVal.lesser(right.getEmbeddedInteger());
+            result = bigintVal < right.getEmbeddedInteger();
         } else {
-            result = bigintVal.lesser(right.getEmbeddedBigInteger());
+            result = bigintVal < right.getEmbeddedBigInteger();
         }
         return (result) ? som.trueObject : som.falseObject;
     };
@@ -48,36 +48,36 @@ function SBigInteger(bigintVal) {
 
     this.primAdd = function (right) {
         if (right instanceof SBigInteger) {
-            return universe.newBiginteger(right.getEmbeddedBigInteger().add(bigintVal));
+            return universe.newBigInteger(right.getEmbeddedBigInteger() + bigintVal);
         } else if (right instanceof SDouble) {
             return universe.newDouble(bigintVal.toJSNumber() + right.getEmbeddedDouble());
         } else {
-            return universe.newBiginteger(bigintVal.add(right.getEmbeddedInteger()))
+            return universe.newBigInteger(bigintVal + right.getEmbeddedInteger())
         }
     };
 
     this.primSubtract = function (right) {
         var result;
         if (right instanceof SBigInteger) {
-            result = bigintVal.subtract(right.getEmbeddedBigInteger());
+            result = bigintVal - right.getEmbeddedBigInteger();
         } else if (right instanceof SDouble) {
             return universe.newDouble(bigintVal.toJSNumber() - right.getEmbeddedDouble());
         } else {
-            result = bigintVal.subtract(right.getEmbeddedInteger())
+            result = bigintVal - right.getEmbeddedInteger()
         }
-        return universe.newBiginteger(result);
+        return universe.newBigInteger(result);
     };
 
     this.primMultiply = function (right) {
         var result;
         if (right instanceof SBigInteger) {
-            result = bigintVal.multiply(right.getEmbeddedBigInteger());
+            result = bigintVal * right.getEmbeddedBigInteger();
         } else if (right instanceof SDouble) {
             return universe.newDouble(bigintVal.toJSNumber() * right.getEmbeddedDouble());
         } else {
-            result = bigintVal.multiply(right.getEmbeddedInteger())
+            result = bigintVal * right.getEmbeddedInteger()
         }
-        return universe.newBiginteger(result);
+        return universe.newBigInteger(result);
     };
 
     this.primDoubleDiv = function (right) {
@@ -95,25 +95,25 @@ function SBigInteger(bigintVal) {
     this.primIntDiv = function (right) {
         var result;
         if (right instanceof SBigInteger) {
-            result = bigintVal.divide(right.getEmbeddedBigInteger());
+            result = bigintVal / right.getEmbeddedBigInteger();
         } else if (right instanceof SDouble) {
             return universe.newDouble(bigintVal.toJSNumber()).primIntDiv(right);
         } else {
-            result = bigintVal.divide(right.getEmbeddedInteger());
+            result = bigintVal / right.getEmbeddedInteger();
         }
-        return universe.newBiginteger(result);
+        return universe.newBigInteger(result);
     };
 
     this.primModulo = function (right) {
         var result;
         if (right instanceof SBigInteger) {
-            result = bigintVal.mod(right.getEmbeddedBigInteger());
+            result = bigintVal % right.getEmbeddedBigInteger();
         } else if (right instanceof SDouble) {
             return universe.newDouble(bigintVal.toJSNumber()).primModulo(right);
         } else {
-            result = bigintVal.mod(right.getEmbeddedInteger());
+            result = bigintVal % right.getEmbeddedInteger();
         }
-        return universe.newBiginteger(result);
+        return universe.newBigInteger(result);
     };
 
     this.primAnd = function (right) {
@@ -123,11 +123,11 @@ function SBigInteger(bigintVal) {
     this.primEquals = function (right) {
         var result;
         if (right instanceof SBigInteger) {
-            result = bigintVal.equals(right.getEmbeddedBigInteger());
+            result = bigintVal == right.getEmbeddedBigInteger();
         } else if (right instanceof SDouble) {
             result = bigintVal.toJSNumber() == right.getEmbeddedDouble();
         } else if (right instanceof SInteger) {
-            result = bigintVal.equals(right.getEmbeddedInteger());
+            result = bigintVal == right.getEmbeddedInteger();
         } else {
             result = false;
         }

--- a/src/som/vmobjects/SClass.js
+++ b/src/som/vmobjects/SClass.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -148,12 +148,12 @@ function SClass(_clazz, numberOfFields) {
             }
         }
 
-        instanceInvokables.getIndexableFields().push(value);
+        _this.setInstanceInvokable(num, value);
         return true;
     }
 
-    this.addInstancePrimitive = function (value) {
-        if (addInstanceInvokable(value)) {
+    this.addInstancePrimitive = function (value, suppressWarning) {
+        if (addInstanceInvokable(value) && suppressWarning !== true) {
             universe.print("Warning: Primitive " + value.getSignature().getString());
             universe.println(" is not in class definition for class "
                 + _this.getName().getString());

--- a/src/som/vmobjects/SDouble.js
+++ b/src/som/vmobjects/SDouble.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,7 +29,7 @@ function SDouble(doubleVal) {
     this.getClass = function () {
         return som.doubleClass;
     };
-    
+
     function asFloat(obj) {
         if (obj instanceof SDouble) {
             return obj.getEmbeddedDouble();
@@ -45,6 +45,11 @@ function SDouble(doubleVal) {
 
     this.primAdd = function (right) {
         return universe.newDouble(doubleVal + asFloat(right));
+    };
+
+    this.primAsInteger = function () {
+        var val = doubleVal > 0 ? Math.floor(doubleVal) : Math.ceil(doubleVal);
+        return universe.newInteger(val);
     };
 
     this.primAsString = function () {

--- a/src/som/vmobjects/SInteger.js
+++ b/src/som/vmobjects/SInteger.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,7 +27,7 @@ function intOrBigInt(val) {
     if (isInIntRange(val)) {
         return universe.newInteger(val | 0);
     } else {
-        return universe.newBiginteger(bigInt(val));
+        return universe.newBigInteger(BigInt(val));
     }
 }
 
@@ -46,11 +46,11 @@ function SInteger(intVal) {
     function toDouble() {
         return universe.newDouble(intVal); // JS numbers are always doubles...
     }
-    
+
     this.primLessThan = function (right) {
         var result;
         if (right instanceof SBigInteger) {
-            result = bigInt(intVal).lesser(right.getEmbeddedBigInteger());
+            result = BigInt(intVal).lesser(right.getEmbeddedBigInteger());
         } else if (right instanceof SDouble) {
             return toDouble.primLessThan(right);
         } else {
@@ -58,14 +58,14 @@ function SInteger(intVal) {
         }
         return (result) ? som.trueObject : som.falseObject;
     };
-    
+
     this.primAsString = function () {
         return universe.newString(intVal.toString());
     };
 
     this.primAdd = function (right) {
         if (right instanceof SBigInteger) {
-            return universe.newBiginteger(
+            return universe.newBigInteger(
                 right.getEmbeddedBigInteger().add(intVal));
         } else if (right instanceof SDouble) {
             return toDouble().primAdd(right);
@@ -77,7 +77,7 @@ function SInteger(intVal) {
 
     this.primSubtract = function (right) {
         if (right instanceof SBigInteger) {
-            return universe.newBiginteger(
+            return universe.newBigInteger(
                 right.getEmbeddedBigInteger().subtract(intVal));
         } else if (right instanceof SDouble) {
             return toDouble().primSubtract(right);
@@ -89,7 +89,7 @@ function SInteger(intVal) {
 
     this.primMultiply = function (right) {
         if (right instanceof SBigInteger) {
-            return universe.newBiginteger(
+            return universe.newBigInteger(
                 right.getEmbeddedBigInteger().multiply(intVal));
         } else if (right instanceof SDouble) {
             return toDouble().primMultiply(right);
@@ -113,8 +113,8 @@ function SInteger(intVal) {
 
     this.primIntDiv = function (right) {
         if (right instanceof SBigInteger) {
-            var result = bigInt(intVal).divide(right.getEmbeddedBigInteger());
-            return universe.newBiginteger(result);
+            var result = BigInt(intVal).divide(right.getEmbeddedBigInteger());
+            return universe.newBigInteger(result);
         } else if (right instanceof SDouble) {
             return toDouble(intVal).primIntDiv(right);
         } else {
@@ -125,8 +125,8 @@ function SInteger(intVal) {
 
     this.primModulo = function (right) {
         if (right instanceof SBigInteger) {
-            var result = bigInt(intVal).mod(right.getEmbeddedBigInteger());
-            return universe.newBiginteger(result);
+            var result = BigInt(intVal).mod(right.getEmbeddedBigInteger());
+            return universe.newBigInteger(result);
         } else if (right instanceof SDouble) {
             return toDouble(intVal).primModulo(right);
         } else {
@@ -149,7 +149,7 @@ function SInteger(intVal) {
     this.primEquals = function (right) {
         var result;
         if (right instanceof SBigInteger) {
-            result = bigInt(intVal).equals(right.getEmbeddedBigInteger());
+            result = BigInt(intVal).equals(right.getEmbeddedBigInteger());
         } else if (right instanceof SDouble) {
             result = intVal == right.getEmbeddedDouble();
         } else if (right instanceof SInteger) {

--- a/src/som/vmobjects/SInteger.js
+++ b/src/som/vmobjects/SInteger.js
@@ -131,10 +131,9 @@ function SInteger(intVal) {
             return toDouble(intVal).primModulo(right);
         } else {
             var r = right.getEmbeddedInteger();
-            var result = Math.floor(intVal % r);
-            if (intVal > 0 && r < 0) {
-                result += r;
-            }
+            // Java has Math.floorMod, JavaScript can use this
+            // but it is likely to be very inefficient
+            var result = Math.floor(((intVal % r) + r) % r);
             return universe.newInteger(result);
         }
     };
@@ -159,5 +158,15 @@ function SInteger(intVal) {
         }
         return (result) ? som.trueObject : som.falseObject;
     };
+
+    this.prim32BitUnsignedValue = function () {
+        var arr = new Uint32Array(1);
+        arr[0] = intVal;
+        return intOrBigInt(arr[0]);
+    }
+
+    this.prim32BitSignedValue = function () {
+        return universe.newInteger(intVal | 0);
+    }
 }
 SInteger.prototype = Object.create(SAbstractObject.prototype);

--- a/src/som/vmobjects/SSymbol.js
+++ b/src/som/vmobjects/SSymbol.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
 * THE SOFTWARE.
 */
 function SSymbol(value) {
-    SAbstractObject.call(this);
+    SString.call(this, value);
     var string = value,
         numberOfSignatureArguments = determineNumberOfSignatureArguments();
 
@@ -72,4 +72,4 @@ function SSymbol(value) {
     Object.freeze(this);
 }
 
-SSymbol.prototype = Object.create(SAbstractObject.prototype);
+SSymbol.prototype = Object.create(SString.prototype);


### PR DESCRIPTION
`BitInt` support in the previously used library was causing test failures.
Now that BigInt support is available in Node.js and a few browser, I think we can use it.
For compatibility see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Browser_compatibility

This also adds all necessary changes to make all mandatory tests for the latest core-lib pass.
This includes support for escape characters in strings, changes to parsing of operators to enable `-` as selector elements, support for literal arrays, number primitives, etc.