### PR TITLE
Added support to embed AreWeFastYet benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 JS_SRC=$(shell libs/deps.py)
 CLOJURE_JAR=build/closure-compiler/compiler.jar
 
+AWFY_ROOT?=../../benchmarks/SOM
+AWFY_SRC=$(wildcard $(AWFY_ROOT)/*.som) $(wildcard $(AWFY_ROOT)/**/*.som)
+
 SOM_SRC=$(wildcard core-lib/**/*.som)
 
 all: build/som.min.js build/node.min.js build/som.full.js build/som-repl.min.js build/som-repl.full.js
@@ -34,8 +37,8 @@ build/som-repl.full.js: $(JS_SRC) src/web-repl.js
 build/som-repl.min.js: $(JS_SRC) src/web-repl.js $(CLOJURE_JAR)
 	java -jar $(CLOJURE_JAR) --language_in=ECMASCRIPT6_STRICT --js_output_file=$@ $(JS_SRC) src/web-repl.js
 
-src_gen/core_lib.js: core-lib src_gen $(SOM_SRC)
-	libs/jsify-core-lib.py > $@
+src_gen/core_lib.js: core-lib src_gen $(SOM_SRC) $(AWFY_SRC)
+	libs/jsify-core-lib.py $(SOM_SRC) $(AWFY_SRC) > $@
 
 core-lib: core-lib/Smalltalk
 

--- a/libs/deps.py
+++ b/libs/deps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 import yaml
-with file('jsTestDriver.conf', 'r') as f:
+with open('jsTestDriver.conf', 'r') as f:
     files = yaml.load(f)['load']
-    print ' '.join(files)
+    print(' '.join(files))

--- a/libs/jsify-core-lib.py
+++ b/libs/jsify-core-lib.py
@@ -7,6 +7,7 @@
 
 import json
 import os
+import sys
 
 core_lib = {}
 
@@ -22,13 +23,9 @@ def add_to_lib(lib, file_name, content):
         current = current[p]
     current[file] = content
     
+for file_name in sys.argv[1:]:
+    with open(file_name, 'r') as f:
+        content = f.read()
+    add_to_lib(core_lib, file_name, content)
 
-for root, dirs, files in os.walk('core-lib'):
-    for file in files:
-        if file.endswith('.som'):
-            file_name = os.path.join(root, file)
-            with open(file_name, 'r') as f:
-                content = f.read()
-            add_to_lib(core_lib, file_name, content)
-
-print "loadCoreLib = function () { return %s; };" % json.dumps(core_lib['core-lib'])
+print("loadCoreLib = function () { return %s; };" % json.dumps(core_lib))

--- a/src/som/compiler/SourcecodeCompiler.js
+++ b/src/som/compiler/SourcecodeCompiler.js
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2014 Stefan Marr, mail@stefan-marr.de
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -58,7 +58,11 @@ function compile(parser, systemClass) {
 function compileClassFile(path, file, systemClass) {
     var source = getFile(path, file + ".som");
     if (source == null) {
-        return null;
+        // retry with "core-lib" prepended
+        source = getFile("core-lib/" + path, file + ".som");
+        if (source == null) {
+            return null;
+        }
     }
 
     var result = compile(new Parser(source, path + '/' + file + '.som'), systemClass);


### PR DESCRIPTION
This changes the jsify script to take the list of files as arguments.

This may need to be revised if we ever have to many files so that the arguments limits are not going to be enough (think some OSes have limits)