### PR TITLE
The #= on Symbol and String should be symmetric

### DIFF
--- a/som.sh
+++ b/som.sh
@@ -3,6 +3,10 @@ pushd `dirname $0` > /dev/null
 SCRIPT_PATH=`pwd`
 popd > /dev/null
 
-git --work-tree=${SCRIPT_PATH} submodule update --init --recursive > /dev/null 2>&1
+if [ ! -f "${SCRIPT_PATH}/core-lib/.git" ]
+then
+  echo Initializing core-lib submodule to have access to the required standard library
+  git --work-tree=${SCRIPT_PATH} submodule update --init --recursive > /dev/null 2>&1
+fi
 
 exec node ${SCRIPT_PATH}/src/node.js "$@"

--- a/src/som/primitives/SymbolPrimitives.js
+++ b/src/som/primitives/SymbolPrimitives.js
@@ -24,6 +24,7 @@
 import { Primitives } from './Primitives.js';
 
 import { universe } from '../vm/Universe.js';
+import { SString } from '../vmobjects/SString.js';
 
 function _asString(_frame, args) {
   return universe.newString(args[0].getString());
@@ -33,6 +34,10 @@ function _equals(_frame, args) {
   const op1 = args[1];
   const op2 = args[0];
   if (op1 === op2) {
+    return universe.trueObject;
+  }
+
+  if (op1 instanceof SString && op1.getEmbeddedString() === op2.getEmbeddedString()) {
     return universe.trueObject;
   }
   return universe.falseObject;


### PR DESCRIPTION
- it’s only defined in String
- there’s no hint that it should behave differently in Symbol which is a subclass
- so, we really should just consider the string content when comparing #foobar = ‘foobar’

See https://github.com/SOM-st/SOM/pull/106 for further details.