### PR TITLE
Added new interpreter microbenchmarks

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -54,6 +54,28 @@ benchmark_suites:
             - WhileLoop:    {extra_args: 10}
             - Mandelbrot:   {extra_args: 30}
 
+    interpreter:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
+        benchmarks:
+            - ArgRead
+            - ArrayReadConst
+            - ArrayWriteConstConst
+            - BlockSend0ConstReturn
+            - Const
+            - FieldConstWrite
+            - FieldRead
+            - FieldReadIncWrite
+            - FieldReadWrite
+            - GlobalRead
+            - LocalConstWrite
+            - LocalRead
+            - LocalReadIncWrite
+            - LocalReadWrite
+            - SelfSend0
+            - SelfSend0BlockConstNonLocalReturn
+
 executors:
     som:  {path: ., executable: som.sh}
 
@@ -64,5 +86,6 @@ experiments:
         suites:
             - micro
             - macro
+            - interpreter
         executions:
             - som


### PR DESCRIPTION
This adds the new microbenchmarks and adds them to the rebench.conf file.
This ensures they are run automatically in CI.

Relies on https://github.com/SOM-st/SOM/pull/121