### PR TITLE
Update core-lib and add benchmarks to rebench.conf

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -54,6 +54,8 @@ benchmark_suites:
             - WhileLoop:    {extra_args: 10}
             - Mandelbrot:   {extra_args: 30}
             - IfNil:        {extra_args: 10}
+            - Knapsack:     {extra_args: 2}
+            - VectorBenchmark: {extra_args: 1}
 
     interpreter:
         description: Basic interpreter benchmarks for comparing performance of most basic concepts.


### PR DESCRIPTION
This PR updates the core-lib to the latest version, which includes a few tests and two benchmarks. The benchmarks are added to the benchmarking setup.